### PR TITLE
removed cardinality on medication.code.display add invariant

### DIFF
--- a/input/fsh/profiles/NcrEhrMedication.fsh
+++ b/input/fsh/profiles/NcrEhrMedication.fsh
@@ -9,7 +9,12 @@ Id: ncr-ehr-medication
     and atcCoding 1..1 MS
 * code.coding[ziCoding].system = "urn:oid:2.16.840.1.113883.2.4.4.8" (exactly)
 * code.coding[ziCoding].code 1..1
-* code.coding[ziCoding].display 1..
 * code.coding[atcCoding].system = "http://www.whocc.no/atc" (exactly)
 * code.coding[atcCoding].code 1..
-* code.coding[atcCoding].display 1..
+* obeys med-display-value-or-text
+
+Invariant: med-display-value-or-text
+Description: "The code element SHALL contain either a display value or a text value."
+Severity: #error
+Expression: "code.coding.display.exists() or code.text.exists()"
+


### PR DESCRIPTION
Removed cardinality on medication.code.display for both slices: ZI-coding and ATC and add an invariant that states that either a medication.code.display or a medication.code.text shall exist.